### PR TITLE
fix do print output confusion

### DIFF
--- a/tools/buildCentral/build_central.py
+++ b/tools/buildCentral/build_central.py
@@ -241,7 +241,7 @@ if args.info:
     exit(0)
 
 def do_print(line):
-    print(line),
+    print(line.encode().rstrip())
 
 not_build = False
 if args.clean and not args.clean_build:


### PR DESCRIPTION
fix stdout output like this
b'/mnt/d/code/message_queue/workspace/common/msg_listener/msg_tput_listener.c:57:19: warning: variable \xe2\x80\x98outputCpu\xe2\x80\x99 set but not used [-Wunused-but-set-variable]\n'
b